### PR TITLE
Allow gcc analyze and clang-tidy in parallel

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -33,8 +33,8 @@ endmacro()
 
 message(STATUS "C++ Jutta Driver Options")
 message(STATUS "=======================================================")
-jutta_driver_option(JUTTA_DRIVER_STATIC_ANALYZE "Set to ON to enable the GCC 10 static analysis. If enabled, JUTTA_DRIVER_ENABLE_LINTING has to be disabled." OFF)
-jutta_driver_option(JUTTA_DRIVER_ENABLE_LINTING "Set to ON to enable clang linting. If enabled, JUTTA_DRIVER_STATIC_ANALYZE has to be disabled." OFF)
+jutta_driver_option(JUTTA_DRIVER_STATIC_ANALYZE "Set to ON to enable the GCC 10 static analysis." OFF)
+jutta_driver_option(JUTTA_DRIVER_ENABLE_LINTING "Set to ON to enable clang linting." OFF)
 message(STATUS "=======================================================")
 
 list(APPEND CMAKE_MODULE_PATH ${CMAKE_BINARY_DIR})

--- a/cmake/gcc_analyze.cmake
+++ b/cmake/gcc_analyze.cmake
@@ -1,9 +1,6 @@
 include(CheckCXXCompilerFlag)
 
 if(JUTTA_DRIVER_STATIC_ANALYZE)
-    if(JUTTA_DRIVER_ENABLE_LINTING)
-        message(FATAL_ERROR "Linting and the GCC static analysis can not be enabled at the same time! Disable either JUTTA_DRIVER_STATIC_ANALYZE or JUTTA_DRIVER_ENABLE_LINTING.")
-    endif()
     if(CMAKE_CXX_COMPILER_ID STREQUAL "GNU")
         check_cxx_compiler_flag("-fanalyzer" HAS_GCC_STATIC_ANALYZER)
         if(HAS_GCC_STATIC_ANALYZER)


### PR DESCRIPTION
Since this project is fairly small ram consumption during build phase are fine.